### PR TITLE
Add scheduled today field for fleet vehicles

### DIFF
--- a/models/field_service_optmization.py
+++ b/models/field_service_optmization.py
@@ -598,6 +598,20 @@ class FleetVehicle(models.Model):
     max_distance = fields.Float(string="Max Distance (Km)",
                                 help="Max total travel distance in kilometers for this vehicle")
 
+    is_scheduled_today = fields.Boolean(
+        string="Scheduled Today",
+        compute="_compute_is_scheduled_today",
+        store=True,
+    )
+
+    @api.depends('delivery_days')
+    def _compute_is_scheduled_today(self):
+        today = fields.Date.context_today(self).strftime('%A').lower()
+        for vehicle in self:
+            vehicle.is_scheduled_today = any(
+                day.name.lower() == today for day in vehicle.delivery_days
+            )
+
     @api.constrains('cost_value', 'cost_type')
     def _check_cost_value(self):
         for record in self:

--- a/models/traktop_optimization.py
+++ b/models/traktop_optimization.py
@@ -223,7 +223,7 @@ class RoutePlaning(models.Model):
             'res_model': 'fleet.vehicle',
             'view_mode': 'pivot,tree',
             'views': [(pivot_id, 'pivot'), (list_id, 'tree')],
-            'domain': [('delivery_days.name', '=', weekday)],
+            'domain': [('is_scheduled_today', '=', True)],
         }
  ################################################################################
 


### PR DESCRIPTION
## Summary
- add computed `is_scheduled_today` on `fleet.vehicle`
- filter vehicles scheduled for today in fleet vehicle report

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863952a5ae0832a8de5140ecb50f549