### PR TITLE
Add vehicle action to list unassigned orders

### DIFF
--- a/models/field_service_optmization.py
+++ b/models/field_service_optmization.py
@@ -618,6 +618,15 @@ class FleetVehicle(models.Model):
             if record.cost_type and not record.cost_value:
                 raise ValidationError(_("Please provide a cost value for the selected cost type."))
 
+    def action_open_unassigned_orders(self):
+        """Open today's unassigned orders and pass the vehicle id in context."""
+        self.ensure_one()
+        action = self.env.ref('mss_route_plan.action_unassigned_orders_today').sudo().read()[0]
+        action['domain'] = [('vehicle_id', '=', False),
+                            ('delivery_date', '=', fields.Date.context_today(self))]
+        action['context'] = {'active_id': self.id}
+        return action
+
 
 class ApiLimitPopup(models.TransientModel):
     _name = 'api.limit.popup'

--- a/views/fleet.xml
+++ b/views/fleet.xml
@@ -66,5 +66,20 @@
                 </page>
             </xpath>
         </field>
+</record>
+
+    <record id="fleet_vehicle_form_unassigned_button" model="ir.ui.view">
+        <field name="name">fleet.vehicle.form.unassigned.button</field>
+        <field name="model">fleet.vehicle</field>
+        <field name="inherit_id" ref="fleet.fleet_vehicle_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="%(action_fleet_open_unassigned)d"
+                        type="action"
+                        class="oe_stat_button"
+                        string="Unassigned Orders"
+                        icon="fa-list"/>
+            </xpath>
+        </field>
     </record>
 </odoo>

--- a/views/reporting_view.xml
+++ b/views/reporting_view.xml
@@ -124,6 +124,14 @@
         <field name="code">action = model.action_fleet_vehicle_report()</field>
     </record>
 
+    <record id="action_fleet_open_unassigned" model="ir.actions.server">
+        <field name="name">Open Unassigned Orders</field>
+        <field name="model_id" ref="fleet.model_fleet_vehicle"/>
+        <field name="binding_model_id" ref="fleet.model_fleet_vehicle"/>
+        <field name="state">code</field>
+        <field name="code">action = records.action_open_unassigned_orders()</field>
+    </record>
+
     <menuitem id="menu_report_vehicle"
               name="Vehicle Report"
               parent="menu_report"


### PR DESCRIPTION
## Summary
- extend `fleet.vehicle` with `action_open_unassigned_orders`
- expose a server action calling the method
- add a smart button on fleet vehicle form to open unassigned orders

## Testing
- `python -m compileall -q models`

------
https://chatgpt.com/codex/tasks/task_e_6863ac0b7900832a959406e6a3f67940