### PR TITLE
Add vehicle pivot action and unassigned order tools

### DIFF
--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_traktop_user,route.planing.user,model_route_planing,base.group_user,1,0,0,0
+access_traktop_user,route.planing.user,model_route_planing,base.group_user,1,1,0,0
 access_traktop_manager,route.planing.manager,model_route_planing,base.group_system,1,1,1,1
 access_sale_order_traktop,sale_order_traktop,model_sale_order,base.group_user,1,1,0,0
 access_stock_picking_traktop,stock_picking_traktop,model_stock_picking,base.group_user,1,1,0,0

--- a/views/reporting_view.xml
+++ b/views/reporting_view.xml
@@ -48,6 +48,33 @@
             </pivot>
         </field>
     </record>
+
+    <!-- Pivot view for vehicles -->
+    <record id="view_fleet_vehicle_pivot" model="ir.ui.view">
+        <field name="name">fleet.vehicle.pivot.report</field>
+        <field name="model">fleet.vehicle</field>
+        <field name="arch" type="xml">
+            <pivot string="Vehicles">
+                <field name="name" type="row"/>
+            </pivot>
+        </field>
+    </record>
+
+    <!-- Tree view for unassigned orders -->
+    <record id="view_unassigned_orders_tree" model="ir.ui.view">
+        <field name="name">route.planing.unassigned.tree</field>
+        <field name="model">route.planing</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="delivery_order_id" widget="many2one_button"/>
+                <field name="partner_id"/>
+                <field name="delivery_address"/>
+                <field name="vehicle_id"/>
+                <field name="delivery_date"/>
+                <button name="action_assign_vehicle" type="object" string="Assign" class="oe_highlight"/>
+            </tree>
+        </field>
+    </record>
     
     <record id="action_report_delivery" model="ir.actions.act_window">
         <field name="name">Delivery Order Analysis</field>
@@ -79,6 +106,20 @@
             </p>
         </field>
     </record>
+
+    <!-- Server action to open vehicle report -->
+    <record id="action_vehicle_report" model="ir.actions.server">
+        <field name="name">Vehicle Report</field>
+        <field name="model_id" ref="model_route_planing"/>
+        <field name="state">code</field>
+        <field name="code">action = model.action_fleet_vehicle_report()</field>
+    </record>
+
+    <menuitem id="menu_report_vehicle"
+              name="Vehicle Report"
+              parent="menu_report"
+              action="action_vehicle_report"
+              sequence="3"/>
 
     <menuitem id="menu_report" 
             name="Reporting" 


### PR DESCRIPTION
## Summary
- allow regular users to update `route.planing`
- add action methods for assigning vehicles and vehicle reporting
- create tree view for unassigned orders
- create pivot view and server action for vehicle report

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `xmllint --noout views/reporting_view.xml`


------
https://chatgpt.com/codex/tasks/task_e_6863907cfbf0832aabd8d0122a5ade86