### PR TITLE
Fix vehicle report action

### DIFF
--- a/models/traktop_optimization.py
+++ b/models/traktop_optimization.py
@@ -216,21 +216,17 @@ class RoutePlaning(models.Model):
 
     @api.model
     def action_fleet_vehicle_report(self):
-        """Open pivot analysis for vehicles filtered by today's weekday."""
+        """Open pivot and list views of vehicles scheduled for today."""
         weekday = fields.Date.context_today(self).strftime('%A').lower()
         pivot_id = self.env.ref('mss_route_plan.view_fleet_vehicle_pivot').id
-        list_id = self.env.ref('mss_route_plan.view_unassigned_orders_tree').id
-        list_id = self.env.ref('mss_route_plan.action_unassigned_orders_today').id
+        tree_id = self.env.ref('mss_route_plan.view_fleet_vehicle_tree_report').id
         return {
             'type': 'ir.actions.act_window',
             'name': 'Vehicle Report',
             'res_model': 'fleet.vehicle',
             'view_mode': 'pivot,tree',
-            'views': [(pivot_id, 'pivot'), (list_id, 'tree')],
+            'views': [(pivot_id, 'pivot'), (tree_id, 'tree')],
             'domain': [('delivery_days.name', '=', weekday)],
-
-            'domain': [('is_scheduled_today', '=', True)],
-
         }
  ################################################################################
 

--- a/views/reporting_view.xml
+++ b/views/reporting_view.xml
@@ -60,6 +60,19 @@
         </field>
     </record>
 
+    <!-- Tree view for vehicles used in the report action -->
+    <record id="view_fleet_vehicle_tree_report" model="ir.ui.view">
+        <field name="name">fleet.vehicle.tree.report</field>
+        <field name="model">fleet.vehicle</field>
+        <field name="arch" type="xml">
+            <tree string="Vehicles">
+                <field name="name"/>
+                <field name="driver_id"/>
+                <field name="delivery_days" widget="many2many_tags"/>
+            </tree>
+        </field>
+    </record>
+
     <!-- Tree view for unassigned orders -->
     <record id="view_unassigned_orders_tree" model="ir.ui.view">
         <field name="name">route.planing.unassigned.tree</field>


### PR DESCRIPTION
## Summary
- add a tree view for vehicles
- fix `action_fleet_vehicle_report` to use the vehicle tree

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863b44bbc94832a8ec28b9bcab46a6f