### PR TITLE
Fix manifest xml order

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -23,11 +23,11 @@ Route planing in Odoo refers to enhancing the delivery and logistics process by 
         'views/sale_order_build_time_views.xml',
         'views/res_partner_gmap.xml',
         'views/res_config_settings_view.xml',
-        'views/fleet.xml',
+        'views/reporting_view.xml',
         'views/fleet_action.xml',
+        'views/fleet.xml',
         'security/traktop_record_rules.xml',
         'views/user_registration.xml',
-        'views/reporting_view.xml',
         # 'data/cron.xml',
     ],
     'demo': [


### PR DESCRIPTION
## Summary
- reorder xml files in the module manifest to load reporting view before fleet actions and fleet actions before fleet views

## Testing
- `python3 -m py_compile __manifest__.py`
- `python3 - <<'PY'
import xml.etree.ElementTree as ET, os
for root, _, files in os.walk('views'):
    for f in files:
        if f.endswith('.xml'):
            ET.parse(os.path.join(root, f))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6863b77909a4832aa4c6188e610cd05b