### PR TITLE
Fix manifest xml order

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -23,11 +23,11 @@ Route planing in Odoo refers to enhancing the delivery and logistics process by 
         'views/sale_order_build_time_views.xml',
         'views/res_partner_gmap.xml',
         'views/res_config_settings_view.xml',
-        'views/fleet.xml',
+        'views/reporting_view.xml',
         'views/fleet_action.xml',
+        'views/fleet.xml',
         'security/traktop_record_rules.xml',
         'views/user_registration.xml',
-        'views/reporting_view.xml',
         # 'data/cron.xml',
     ],
     'demo': [

--- a/views/fleet_action.xml
+++ b/views/fleet_action.xml
@@ -2,7 +2,7 @@
     <record id="action_fleet_open_unassigned" model="ir.actions.act_window">
         <field name="name">Today's Unassigned Orders</field>
         <field name="res_model">route.planing</field>
-        <field name="view_mode">tree</field>
+        <field name="view_mode">list</field>
         <field name="view_id" ref="view_unassigned_orders_tree"/>
         <field name="domain">['&amp;', ('delivery_date', '=', context_today()), ('vehicle_id', '=', False)]</field>
     </record>

--- a/views/reporting_view.xml
+++ b/views/reporting_view.xml
@@ -65,11 +65,11 @@
         <field name="name">fleet.vehicle.tree.report</field>
         <field name="model">fleet.vehicle</field>
         <field name="arch" type="xml">
-            <tree string="Vehicles">
+            <list string="Vehicles">
                 <field name="name"/>
                 <field name="driver_id"/>
                 <field name="delivery_days" widget="many2many_tags"/>
-            </tree>
+            </list>
         </field>
     </record>
 
@@ -78,14 +78,14 @@
         <field name="name">route.planing.unassigned.tree</field>
         <field name="model">route.planing</field>
         <field name="arch" type="xml">
-            <tree>
+            <list>
                 <field name="delivery_order_id" widget="many2one_button"/>
                 <field name="partner_id"/>
                 <field name="delivery_address"/>
                 <field name="vehicle_id"/>
                 <field name="delivery_date"/>
                 <button name="action_assign_vehicle" type="object" string="Assign" class="oe_highlight"/>
-            </tree>
+            </list>
         </field>
     </record>
 
@@ -93,7 +93,7 @@
     <record id="action_unassigned_orders_today" model="ir.actions.act_window">
         <field name="name">Today's Unassigned Orders</field>
         <field name="res_model">route.planing</field>
-        <field name="view_mode">tree</field>
+        <field name="view_mode">list</field>
         <field name="view_id" ref="view_unassigned_orders_tree"/>
         <field name="domain">['&amp;',('delivery_date','=',context_today()),('vehicle_id','=',False)]</field>
     </record>


### PR DESCRIPTION
## Summary
- reorder xml files in the module manifest to load reporting view before fleet actions and fleet actions before fleet views
- switch deprecated tree view references to list view

## Testing
- `python3 -m py_compile __manifest__.py`
- `python3 - <<'PY'
import xml.etree.ElementTree as ET, os
for root, _, files in os.walk('views'):
    for f in files:
        if f.endswith('.xml'):
            ET.parse(os.path.join(root, f))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6863b77909a4832aa4c6188e610cd05b