### PR TITLE
Add action to list today's unassigned pickings

### DIFF
--- a/models/field_service_optmization.py
+++ b/models/field_service_optmization.py
@@ -604,6 +604,27 @@ class FleetVehicle(models.Model):
             if record.cost_type and not record.cost_value:
                 raise ValidationError(_("Please provide a cost value for the selected cost type."))
 
+    def action_view_unassigned_pickings(self):
+        """Return an action showing today's unassigned delivery orders."""
+        today = fields.Date.context_today(self)
+        start_dt = datetime.combine(today, datetime.min.time())
+        end_dt = datetime.combine(today, datetime.max.time())
+
+        domain = [
+            ('vehicle_id', '=', False),
+            ('scheduled_date', '>=', fields.Datetime.to_string(start_dt)),
+            ('scheduled_date', '<=', fields.Datetime.to_string(end_dt)),
+        ]
+
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Unassigned Pickings'),
+            'res_model': 'stock.picking',
+            'view_mode': 'tree,form',
+            'domain': domain,
+            'context': self.env.context,
+        }
+
 
 class ApiLimitPopup(models.TransientModel):
     _name = 'api.limit.popup'

--- a/views/fleet.xml
+++ b/views/fleet.xml
@@ -105,6 +105,8 @@
                 <field name="license_plate"/>
                 <field name="driver_id"/>
                 <field name="is_scheduled_today"/>
+                <button name="action_view_unassigned_pickings" type="object"
+                        string="Unassigned Deliveries" class="oe_link"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- add `action_view_unassigned_pickings` on fleet vehicles
- show button in vehicle list to open unassigned pickings

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863d5efb114832abdb17361946bbf21