### PR TITLE
Add vehicle assignment client action

### DIFF
--- a/models/traktop_optimization.py
+++ b/models/traktop_optimization.py
@@ -511,6 +511,18 @@ class RoutePlaning(models.Model):
         if 'vehicle_id' in vals and not self.env.context.get('from_optimization', False):
             vals['manual_vehicle_override'] = True
         return super(RoutePlaning, self).write(vals)
+
+    def assign_to_vehicle(self, vehicle_id):
+        """Assign this record to the given vehicle."""
+        self.ensure_one()
+        vehicle = self.env['fleet.vehicle'].browse(vehicle_id)
+        if not vehicle:
+            raise UserError(_('Invalid vehicle.'))
+        self.sudo().write({
+            'vehicle_id': vehicle.id,
+            'manual_vehicle_override': True,
+        })
+        return True
     
 ######################################################################################
     @api.model

--- a/static/src/js/vehicle_assignment.js
+++ b/static/src/js/vehicle_assignment.js
@@ -1,0 +1,102 @@
+/** @odoo-module **/
+import { Component, useRef, useState, onWillStart, onMounted } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { pivotView } from "@web/views/pivot/pivot_view";
+
+export class VehicleAssignment extends Component {
+    static template = "mss_route_plan.VehicleAssignment";
+
+    setup() {
+        this.orm = useService("orm");
+        this.viewService = useService("view");
+        this.notification = useService("notification");
+        this.pivotRef = useRef("pivotContainer");
+        this.listRef = useRef("listContainer");
+        this.state = useState({ vehicleId: null });
+
+        onWillStart(async () => {
+            const views = await this.viewService.loadViews({
+                resModel: "fleet.vehicle",
+                views: [[false, "pivot"]],
+            });
+            this.pivotArch = views.views.pivot.arch;
+            this.pivotFields = views.views.pivot.fields;
+        });
+
+        onMounted(async () => {
+            await this._renderPivot();
+            await this._loadList();
+        });
+    }
+
+    _todayWeekday() {
+        return new Date().toLocaleDateString("en-US", { weekday: "long" }).toLowerCase();
+    }
+
+    async _renderPivot() {
+        const { Model, Renderer, Controller } = pivotView;
+        this.pivotModel = new Model(this.env, {
+            resModel: "fleet.vehicle",
+            domain: [["delivery_days.name", "=", this._todayWeekday()]],
+            context: {},
+            fields: this.pivotFields,
+            arch: this.pivotArch,
+        });
+        await this.pivotModel.load();
+        const renderer = new Renderer(this.env, { model: this.pivotModel });
+        this.pivotController = new Controller(this.env, { model: this.pivotModel, renderer });
+        this.pivotController.mount(this.pivotRef.el);
+        this.pivotRef.el.addEventListener("click", (ev) => {
+            const cell = ev.target.closest("th[data-row-id]");
+            if (cell) {
+                const vid = parseInt(cell.dataset.rowId, 10);
+                if (!isNaN(vid)) {
+                    this.state.vehicleId = vid;
+                    this._loadList();
+                }
+            }
+        });
+    }
+
+    async _loadList() {
+        const today = new Date().toISOString().split("T")[0];
+        const domain = [
+            ["delivery_date", ">=", today + " 00:00:00"],
+            ["delivery_date", "<=", today + " 23:59:59"],
+            ["vehicle_id", "=", false],
+        ];
+        const records = await this.orm.searchRead("route.planing", domain, [
+            "id",
+            "delivery_order_id",
+            "delivery_address",
+        ]);
+        this._renderList(records);
+    }
+
+    _renderList(records) {
+        const el = this.listRef.el;
+        el.innerHTML = "";
+        records.forEach((rec) => {
+            const li = document.createElement("li");
+            li.className = "list-group-item d-flex justify-content-between align-items-center";
+            const name = rec.delivery_order_id ? rec.delivery_order_id[1] : rec.id;
+            li.innerHTML = `<span>${name} - ${rec.delivery_address || ""}</span>`;
+            const btn = document.createElement("button");
+            btn.className = "btn btn-primary btn-sm";
+            btn.textContent = this.env._t("Assign to This Vehicle");
+            btn.addEventListener("click", async () => {
+                if (!this.state.vehicleId) {
+                    this.notification.add(this.env._t("Select a vehicle first."), { type: "danger" });
+                    return;
+                }
+                await this.orm.call("route.planing", "assign_to_vehicle", [rec.id, this.state.vehicleId]);
+                this._loadList();
+            });
+            li.appendChild(btn);
+            el.appendChild(li);
+        });
+    }
+}
+
+registry.category("actions").add("vehicle_assignment", VehicleAssignment);

--- a/static/src/xml/vehicle_assignment.xml
+++ b/static/src/xml/vehicle_assignment.xml
@@ -1,0 +1,8 @@
+<templates xml:space="preserve">
+    <t t-name="mss_route_plan.VehicleAssignment" owl="1">
+        <div class="o_vehicle_assignment">
+            <div t-ref="pivotContainer" class="o_vehicle_pivot mb-3" style="height:300px;"/>
+            <ul t-ref="listContainer" class="list-group"/>
+        </div>
+    </t>
+</templates>

--- a/views/traktop.xml
+++ b/views/traktop.xml
@@ -242,6 +242,11 @@
       <field name="view_id" ref="view_field_service_custom_list"/>
     </record>
 
+    <record id="action_vehicle_assignment" model="ir.actions.client">
+      <field name="name">Vehicle Assignment</field>
+      <field name="tag">vehicle_assignment</field>
+    </record>
+
     <!-- =================================================================== -->
     <!-- Menu Items -->
     <!-- =================================================================== -->
@@ -257,11 +262,17 @@
         parent="traktop_main_menu" 
         sequence="10"/>
 
-    <menuitem id="menu_field_services" 
-        name="Field Services" 
-        action="action_field_services" 
-        parent="traktop_main_menu" 
+    <menuitem id="menu_field_services"
+        name="Field Services"
+        action="action_field_services"
+        parent="traktop_main_menu"
         sequence="20"/>
+
+    <menuitem id="menu_vehicle_assignment"
+        name="Vehicle Assignment"
+        action="action_vehicle_assignment"
+        parent="traktop_main_menu"
+        sequence="25"/>
 
     <!-- This is the parent menu for all map views -->
     <menuitem id="menu_maps_parent" 


### PR DESCRIPTION
## Summary
- add `assign_to_vehicle` server method
- implement new VehicleAssignment client action with pivot and order list
- add QWeb template for the vehicle assignment UI
- expose client action via new menu entry

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863deda4158832a9e3e5e6b59e65852