### PR TITLE
Fix: remove unused method

### DIFF
--- a/models/traktop_optimization.py
+++ b/models/traktop_optimization.py
@@ -115,8 +115,6 @@ class RoutePlaning(models.Model):
             record.usage_display = registration.usage_display or 'N/A'
 
 
-    def _compute_usage(self):
-        self.env
     def action_view_products(self):
         self.ensure_one()
         # Use your module’s XML‑ID here

--- a/models/traktop_optimization_backup.py
+++ b/models/traktop_optimization_backup.py
@@ -115,8 +115,6 @@ class RoutePlaning(models.Model):
             record.usage_display = registration.usage_display or 'N/A'
 
 
-    def _compute_usage(self):
-        self.env
     def action_view_products(self):
         self.ensure_one()
         # Use your module’s XML‑ID here


### PR DESCRIPTION
## Summary
- cleanup `models/traktop_optimization.py` by deleting the unfinished `_compute_usage` method
- remove the same unused code from the backup file

## Testing
- `python3 -m compileall -q models/traktop_optimization.py models/traktop_optimization_backup.py`

------
https://chatgpt.com/codex/tasks/task_e_6864b7017350832aa7a1239bcb5a8821