### PR TITLE
Fix Route Planning menu label

### DIFF
--- a/views/traktop.xml
+++ b/views/traktop.xml
@@ -246,9 +246,9 @@
     <!-- Menu Items -->
     <!-- =================================================================== -->
     <menuitem id="traktop_main_menu"
-        name="Route Planing"
-        action="action_open_route_optimization" 
-        sequence="10" 
+        name="Route Planning"
+        action="action_open_route_optimization"
+        sequence="10"
         web_icon="mss_route_plan,static/description/icon.png"/>
     
     <menuitem id="traktop_menu" 


### PR DESCRIPTION
## Summary
- correct a typo in the `traktop_main_menu` menu label

## Testing
- `python -m py_compile $(find . -name "*.py" | tr '\n' ' ')`


------
https://chatgpt.com/codex/tasks/task_e_6864ca1a8690832ab84816353ef75a3c