### PR TITLE
Add weekly order planning views

### DIFF
--- a/views/traktop.xml
+++ b/views/traktop.xml
@@ -13,6 +13,30 @@
         </list>
       </field>
     </record>
+    <record id="view_route_planing_week_list" model="ir.ui.view">
+      <field name="name">route.planing.week.list</field>
+      <field name="model">route.planing</field>
+      <field name="arch" type="xml">
+        <list string="Weekly Deliveries" create="false" delete="false">
+          <field name="delivery_order_id"/>
+          <field name="partner_id"/>
+          <field name="vehicle_id"/>
+          <field name="delivery_date"/>
+          <field name="delivery_weekday"/>
+        </list>
+      </field>
+    </record>
+
+    <record id="view_route_planing_week_pivot" model="ir.ui.view">
+      <field name="name">route.planing.week.pivot</field>
+      <field name="model">route.planing</field>
+      <field name="arch" type="xml">
+        <pivot string="Delivery Count">
+          <field name="delivery_weekday" type="col"/>
+          <field name="id" type="measure" string="Orders"/>
+        </pivot>
+      </field>
+    </record>
     <record id="action_traktop_products" model="ir.actions.act_window">
       <field name="name">Order Products</field>
       <field name="res_model">stock.move</field>
@@ -222,6 +246,23 @@
       <field name="view_id" ref="view_traktop_multiple_markers_form"/>
       <field name="target">current</field>
     </record>
+    <record id="action_route_plan_week" model="ir.actions.act_window">
+      <field name="name">Upcoming Week Orders</field>
+      <field name="res_model">route.planing</field>
+      <field name="view_mode">list,pivot</field>
+      <field name="view_ids" eval="[
+            (5, 0, 0),
+            (0, 0, {'view_mode': 'list', 'view_id': ref('view_route_planing_week_list')}),
+            (0, 0, {'view_mode': 'pivot', 'view_id': ref('view_route_planing_week_pivot')})
+        ]"/>
+      <field name="context">{'group_by':'delivery_weekday'}</field>
+    </record>
+    <record id="action_fetch_week_orders" model="ir.actions.server">
+      <field name="name">Load Upcoming Week</field>
+      <field name="model_id" ref="model_route_planing"/>
+      <field name="state">code</field>
+      <field name="code">action = model.action_fetch_delivery_orders_week()</field>
+    </record>
     <record id="action_field_service_multiple_markers" model="ir.actions.act_window">
       <field name="name">Field Service Map</field>
       <field name="res_model">field.service.route.step</field>
@@ -251,11 +292,17 @@
         sequence="10"
         web_icon="mss_route_plan,static/description/icon.png"/>
     
-    <menuitem id="traktop_menu" 
-        name="Delivery Orders" 
-        action="action_traktop" 
-        parent="traktop_main_menu" 
+    <menuitem id="traktop_menu"
+        name="Delivery Orders"
+        action="action_traktop"
+        parent="traktop_main_menu"
         sequence="10"/>
+
+    <menuitem id="menu_route_plan_week"
+        name="Upcoming Week"
+        action="action_fetch_week_orders"
+        parent="traktop_main_menu"
+        sequence="15"/>
 
     <menuitem id="menu_field_services" 
         name="Field Services" 


### PR DESCRIPTION
## Summary
- compute weekday on route.planing
- fetch deliveries for the upcoming week
- create list and pivot views for weekly orders
- expose a menu entry and action under Route Planning

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864cb53f5e8832abd248419af6ff86e